### PR TITLE
Add platform argument to nomad images to run on ARM platform

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -69,6 +69,7 @@ services:
   worker:
     restart: unless-stopped
     image: ghcr.io/fairmat-nfdi/nomad-distro-template:main
+    platform: linux/amd64
     container_name: nomad_oasis_worker
     environment:
       NOMAD_SERVICE: nomad_oasis_worker
@@ -92,6 +93,7 @@ services:
   app:
     restart: unless-stopped
     image: ghcr.io/fairmat-nfdi/nomad-distro-template:main
+    platform: linux/amd64
     container_name: nomad_oasis_app
     environment:
       NOMAD_SERVICE: nomad_oasis_app
@@ -131,6 +133,7 @@ services:
   north:
     restart: unless-stopped
     image: ghcr.io/fairmat-nfdi/nomad-distro-template:main
+    platform: linux/amd64
     container_name: nomad_oasis_north
     environment:
       NOMAD_SERVICE: nomad_oasis_north
@@ -166,6 +169,7 @@ services:
   logtransfer:
     restart: unless-stopped
     image: ghcr.io/fairmat-nfdi/nomad-distro-template:main
+    platform: linux/amd64
     container_name: nomad_oasis_logtransfer
     environment:
       NOMAD_SERVICE: nomad_oasis_logtransfer
@@ -203,6 +207,7 @@ services:
   # jupyterlab image: (this is only used to pull the image, no service is run for this)
   jupyterlab_image:
     image: ghcr.io/fairmat-nfdi/nomad-distro-template/jupyter:main
+    platform: linux/amd64
     container_name: nomad_jupyter_image
     pull_policy: always
     entrypoint: ["true"]


### PR DESCRIPTION
Add platform argument to nomad images to run on ARM platform (my Apple M4 machine for example)


```
yang@dhcp-47-62 nomad-distro-template % docker compose up --pull always -d
[+] Running 26/26
 ✔ jupyterlab_image Pulled                                                                                                        0.6s 
 ✔ mongo Pulled                                                                                                                   1.6s 
 ✔ app Pulled                                                                                                                     0.6s 
 ✔ elastic Pulled                                                                                                                 8.5s 
 ✔ worker Pulled                                                                                                                  0.6s 
 ✔ rabbitmq Pulled                                                                                                                1.7s 
 ✔ proxy Pulled                                                                                                                   3.3s 
 ✔ north Pulled                                                                                                                   0.6s 
[+] Running 8/8
 ✔ Network nomad_oasis_network     Created                                                                                        0.0s 
 ✔ Container nomad_oasis_north     Healthy                                                                                       11.8s 
 ✔ Container nomad_oasis_rabbitmq  Healthy                                                                                        6.1s 
 ✔ Container nomad_oasis_mongo     Healthy                                                                                        6.1s 
 ✔ Container nomad_oasis_elastic   Healthy                                                                                       11.1s 
 ✔ Container nomad_oasis_worker    Started                                                                                       10.9s 
 ✔ Container nomad_oasis_app       Healthy                                                                                      149.9s 
 ✔ Container nomad_oasis_proxy     Started                                                                                      150.0s 

yang@dhcp-47-62 nomad-distro-template % curl localhost/nomad-oasis/alive  
"I am, alive!"%

yang@dhcp-47-62 ~ % uname -a
Darwin dhcp-47-62.physik.hu-berlin.de 24.4.0 Darwin Kernel Version 24.4.0: Wed Mar 19 21:17:35 PDT 2025; root:xnu-11417.101.15~1/RELEASE_ARM64_T6041 arm64
```

@blueraft 