### PR TITLE
Split jupyter build stage into multiple stages

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -41,8 +41,6 @@ jobs:
   update-lockfile:
     name: Update Python Lock File
     runs-on: ubuntu-latest
-    outputs:
-      scm_version: ${{ steps.get_scm_version.outputs.scm_version }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -72,13 +70,6 @@ jobs:
             git commit -m "Update lockfile"
             git push origin -o ci.skip # prevent triggering the pipeline again
           fi
-
-      - name: Get SCM Version
-        id: get_scm_version
-        run: |
-          SCM_VERSION=$(uvx --with setuptools_scm python -m setuptools_scm)
-          echo "SCM version: $SCM_VERSION"
-          echo "scm_version=$SCM_VERSION" >> "$GITHUB_OUTPUT"
 
   # Job 2: Run unit tests for all of the plugin
   plugin_unit_tests:
@@ -128,9 +119,6 @@ jobs:
       matrix:
         service: [app, jupyter]
 
-    env:
-      SETUPTOOLS_SCM_PRETEND_VERSION_FOR_NOMAD_DISTRIBUTION: ${{ needs.update-lockfile.outputs.scm_version }}
-
     steps:
       - uses: actions/checkout@v4
         with:
@@ -156,7 +144,6 @@ jobs:
         with:
           context: .
           build-args: |
-            SETUPTOOLS_SCM_PRETEND_VERSION_FOR_NOMAD_DISTRIBUTION=${{ env.SETUPTOOLS_SCM_PRETEND_VERSION_FOR_NOMAD_DISTRIBUTION }}
             UV_VERSION=${{ env.UV_VERSION }}
             PYTHON_VERSION=${{ env.PYTHON_VERSION }}
             NOMAD_DOCS_REPO=${{ env.NOMAD_DOCS_REPO }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -15,6 +15,7 @@ env:
   REGISTRY: ghcr.io
   UV_VERSION: 0.6
   PYTHON_VERSION: 3.12
+  JUPYTER_VERSION: 2025-04-14
   # If you want to include custom documentation, create a fork of the repo below and link the forked repo here
   NOMAD_DOCS_REPO: https://github.com/FAIRmat-NFDI/nomad-docs.git
   # If you want to skip the tests for some plugins, add them to the list below
@@ -159,6 +160,7 @@ jobs:
             UV_VERSION=${{ env.UV_VERSION }}
             PYTHON_VERSION=${{ env.PYTHON_VERSION }}
             NOMAD_DOCS_REPO=${{ env.NOMAD_DOCS_REPO }}
+            JUPYTER_VERSION=${{ env.JUPYTER_VERSION }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           target: ${{ matrix.service == 'jupyter' && 'jupyter' || 'final' }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -206,11 +206,6 @@ RUN apt-get update \
       texlive-xetex \
       texlive-fonts-recommended \
       texlive-plain-generic \
-      # `nbconvert` dependencies
-      # https://nbconvert.readthedocs.io/en/latest/install.html#installing-tex
-      texlive-xetex \
-      texlive-fonts-recommended \
-      texlive-plain-generic \
       # clean cache and logs
       && rm -rf /var/lib/apt/lists/* /var/log/* /var/tmp/* ~/.npm
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -206,6 +206,11 @@ RUN apt-get update \
       texlive-xetex \
       texlive-fonts-recommended \
       texlive-plain-generic \
+      # `nbconvert` dependencies
+      # https://nbconvert.readthedocs.io/en/latest/install.html#installing-tex
+      texlive-xetex \
+      texlive-fonts-recommended \
+      texlive-plain-generic \
       # clean cache and logs
       && rm -rf /var/lib/apt/lists/* /var/log/* /var/tmp/* ~/.npm
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -94,9 +94,8 @@ RUN adduser \
 # Install UV
 COPY --from=uv_image /uv /bin/uv
 
-ARG SETUPTOOLS_SCM_PRETEND_VERSION_FOR_NOMAD_DISTRIBUTION='0.0'
-
 RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=source=.git,target=.git,type=bind \
     --mount=type=bind,source=uv.lock,target=uv.lock \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
     uv sync --extra plugins

--- a/README.md
+++ b/README.md
@@ -234,8 +234,10 @@ This image has been added to the [`configs/nomad.yaml`](configs/nomad.yaml) duri
 
 We currently use `quay.io/jupyter/base-notebook:2025-04-14` as our base image for Jupyter. While it includes the necessary Python packages, it does not come with `R` or `Julia` pre-installed.
 If you need support for those languages, you can switch to `quay.io/jupyter/datascience-notebook:2025-04-04`, which includes both `R` and `Julia`.
+The Jupyter image does not include `gcc` or `build-essential` by default. If you want to allow users to install Python packages that require compilation while running a notebook, you'll need to install these tools in the [Dockerfile](./Dockerfile#L172) or switch the base image to `quay.io/jupyter/datascience-notebook:2025-04-04`.
+However, including these packages can increase the image size and may introduce security risks if arbitrary code is compiled at runtime.
 
-Note that the base-notebook image is more lightweight and uses less disk space compared to the datascience-notebook image.
+Note that the `base-notebook` image is more lightweight and uses less disk space compared to the `datascience-notebook` image.
 
 The image is quite large and might cause a timeout the first time it is run. In order to avoid this you can pre pull the image with:
 


### PR DESCRIPTION
Avoid installing `gcc` and `build-essentials` in the final image