### PR TITLE
Add additional trigger for initialization workflow

### DIFF
--- a/.github/workflows/initialize.yml
+++ b/.github/workflows/initialize.yml
@@ -3,6 +3,8 @@ name: Template Repository Initialization
 on:
   # Triggers the workflow on creation of repository
   create:
+  push:
+    branches: ["main"]
   workflow_dispatch:
 
 env:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Click [here](https://github.com/new?template_name=nomad-distro-template&template
 to use this template, or click the `Use this template` button in the upper right corner of
 the main GitHub page for this template.
 
-> [!IMPORTANT]
+> [!CAUTION]
 > The templated repository will run a GitHub action on creation which might take a few minutes.
 > After the workflow finishes you should refresh the page and this message should disappear.
 > If this message persists you might need to trigger the workflow manually by navigating to the


### PR DESCRIPTION
The initialization workflow seems to run less and less on template initialization lately. However, the publish always seems to get triggered by the initial commit to the main branch. Since we check the repository name anyways before running I think this should be fine.