### PR TITLE
bump temporalio docker image version to 1.29.1 to support heartbeat

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -86,7 +86,7 @@ services:
       - POSTGRES_SEEDS=postgresql
       - TEMPORAL_ADDRESS=temporal:7233
       - TEMPORAL_CLI_ADDRESS=temporal:7233
-    image: docker.io/temporalio/auto-setup:1.28
+    image: docker.io/temporalio/auto-setup:1.29.1
     healthcheck:
       test: >
         bash -c '


### PR DESCRIPTION
https://github.com/temporalio/sdk-python/releases
> Server version [1.29.1](https://github.com/temporalio/temporal/releases/tag/v1.29.1) and newer supports this feature. This feature will be enabled by default, although this currently requires a server dynamic config flag, --dynamic-config-value frontend.WorkerHeartbeatsEnabled=true to enable. Currently, the only way to interact with this new data is to also enable the flag --dynamic-config-value frontend.ListWorkersEnabled=true, then use CLI commands temporal worker list and temporal worker describe to query the data. If heartbeating is enabled with a server version older or with the config flag off, a single warning log Worker heartbeating configured for runtime, but server version does not support it. on worker startup will emit.

- [ ] Still need to pass this flag