### PR TITLE
Move Docker storage to /mnt/docker before build and final tests

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -139,6 +139,14 @@ jobs:
           #   image_suffix: /cpu-action
 
     steps:
+      - name: Move Docker storage to /mnt/docker
+        run: |
+          sudo systemctl stop docker
+          sudo mkdir -p /mnt/docker
+          sudo mv /var/lib/docker /mnt/docker
+          sudo ln -s /mnt/docker /var/lib/docker
+          sudo systemctl start docker
+          
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref || github.ref_name }}
@@ -197,7 +205,15 @@ jobs:
         with:
           ref: ${{ github.head_ref || github.ref_name }}
           submodules: true
-
+          
+      - name: Move Docker storage to /mnt/docker
+        run: |
+          sudo systemctl stop docker
+          sudo mkdir -p /mnt/docker
+          sudo mv /var/lib/docker /mnt/docker
+          sudo ln -s /mnt/docker /var/lib/docker
+          sudo systemctl start docker
+          
       - uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}


### PR DESCRIPTION
Available disk space in the root of the VM provided by github for the actions is ~15GB, which might be not enough for plugins with heavy dependencies (ML models etc.). There is though /mnt volume with >60GB available, we can use this.

This edit was tested by @ka-sarthak and me on two separate oases built with the template and seems to solve our disk space issues. @lauri-codes @blueraft What do you think? Would this be breaking something else for the template?