### PR TITLE
`nginx` use custom 404 page as `error_page`

### DIFF
--- a/configs/nginx_base_conf
+++ b/configs/nginx_base_conf
@@ -37,14 +37,12 @@ location @redirect_to_index {
 
 location /nomad-oasis/docs/ {
     proxy_intercept_errors on;
-    error_page 404 = /nomad-oasis/docs/404.html;
+    error_page 404 = @docs404redirect;
     proxy_pass http://app:8000;
 }
 
-location = /nomad-oasis/docs/404.html {
-    internal;
-    proxy_pass http://app:8000;
-    proxy_intercept_errors off;
+location @docs404redirect {
+    return 302 /nomad-oasis/docs/404.html;
 }
 
 location ~ \/gui\/(service-worker\.js|meta\.json)$ {


### PR DESCRIPTION
Fix https://github.com/FAIRmat-NFDI/nomad-docs/issues/199

`nginx` reference: https://docs.nginx.com/nginx/admin-guide/web-server/web-server/#handle-errors

[Kooha-2026-02-03-13-18-39.webm](https://github.com/user-attachments/assets/b6f84f26-86d4-41c6-8cfd-2b9645fea92e)



---

### Some note for my own reference (or anyone reading this later)

Currently workflow is `mkdocs` build static pages -> `fastapi` serve them behind `nginx`. So we would need `nginx` to handle errors (404 in this case) instead of `mkdocs` (as no `mkdocs` server would be running).

The original issue (the broken page) was due to use to relative path for asset in 404 HTML (built via `mkdocs`) page, so when `nginx` serves a new page as error page, the browser wouldn't refresh and would try to look for asset still relative to the broken page, for example (and therefore a broken page would be displayed):
```
INFO:     172.17.0.2:38132 - "GET /nomad-oasis/docs/howto/overview-typo.html HTTP/1.0" 404 Not Found
INFO:     172.17.0.2:38134 - "GET /nomad-oasis/docs/404.html HTTP/1.0" 200 OK
INFO:     172.17.0.2:38162 - "GET /nomad-oasis/docs/howto/assets/stylesheets/palette.06af60db.min.css HTTP/1.0" 404 Not Found
INFO:     172.17.0.2:38168 - "GET /nomad-oasis/docs/howto/stylesheets/extra.css HTTP/1.0" 404 Not Found
INFO:     172.17.0.2:38148 - "GET /nomad-oasis/docs/howto/assets/stylesheets/main.2afb09e1.min.css HTTP/1.0" 404 Not Found
INFO:     172.17.0.2:38186 - "GET /nomad-oasis/docs/howto/assets/javascripts/glightbox.min.js HTTP/1.0" 404 Not Found
INFO:     172.17.0.2:38194 - "GET /nomad-oasis/docs/howto/assets/nomad-logo.png HTTP/1.0" 404 Not Found
INFO:     172.17.0.2:38174 - "GET /nomad-oasis/docs/howto/assets/stylesheets/glightbox.min.css HTTP/1.0" 404 Not Found
```

and by using a named location (`@docs404redirect`), we forced the broswer to reload and therefore the asset path would be correct for the 404 page. But there're still problems I don't understand yet:
- seems inside the named location, still using 404 (`return 404 /nomad-oasis/docs/404.html;`) wouldn't lead to reload 

The other way to fix is to use absolute PATH, but [doesn't seem to be nicely supported yet](https://github.com/mkdocs/mkdocs/issues/192). I tried [a "hacky" way to replace the URL](https://github.com/FAIRmat-NFDI/nomad-docs/pull/201/changes/85492bb9a3e86ee619b850c0f6164f97a86c395f) but it would need hard-coding the URL prefix which is fragile across different deployments (it works though)

