### PR TITLE
[`>1.4.1`] Remove `nginx` handling of 404 and redirect `/docs/` to `/docs/index.html`, use `fastapi` (via `nomad-lab`) instead 

### DIFF
--- a/configs/nginx_base_conf
+++ b/configs/nginx_base_conf
@@ -36,16 +36,7 @@ location @redirect_to_index {
 }
 
 location /nomad-oasis/docs/ {
-    # TODO: temp fix: redirect /docs/ to /docs/index.html
-    rewrite ^/nomad-oasis/docs/$ /nomad-oasis/docs/index.html break;
-
-    proxy_intercept_errors on;
-    error_page 404 = @docs404redirect;
     proxy_pass http://app:8000;
-}
-
-location @docs404redirect {
-    return 302 /nomad-oasis/docs/404.html;
 }
 
 location ~ \/gui\/(service-worker\.js|meta\.json)$ {


### PR DESCRIPTION
Follow up https://github.com/FAIRmat-NFDI/nomad-distro-template/pull/176, I believe [the `fastapi` fix is working](https://gitlab.mpcdf.mpg.de/nomad-lab/nomad-FAIR/-/merge_requests/2871), so **after a new `nomad-lab` release** (`>1.4.1`) we could remove:
- `nginx` handling of 404 to `404.html`, and redirect of `/docs/` to `/docs/index.html`
- [ ] apply the same to https://gitlab.mpcdf.mpg.de/nomad-lab/nomad-distro/-/blob/main/ops/kubernetes/nomad/templates/proxy/configmap.yml?ref_type=heads
