### PR TITLE
Temp fix: `nginx` redirect `/docs(/)` to `/docs/index.html`

### DIFF
--- a/configs/nginx_base_conf
+++ b/configs/nginx_base_conf
@@ -36,6 +36,9 @@ location @redirect_to_index {
 }
 
 location /nomad-oasis/docs/ {
+    # TODO: temp fix: redirect /docs/ to /docs/index.html
+    rewrite ^/nomad-oasis/docs/$ /nomad-oasis/docs/index.html break;
+
     proxy_intercept_errors on;
     error_page 404 = @docs404redirect;
     proxy_pass http://app:8000;


### PR DESCRIPTION
This [should have been fixed from the `fastapi` side](https://gitlab.mpcdf.mpg.de/nomad-lab/nomad-FAIR/-/merge_requests/2871) but it would need a new `nomad-lab` release

---

before:
```
➜  nomad-distro-template git:(main) curl -I http://localhost/nomad-oasis/docs/
HTTP/1.1 302 Moved Temporarily
Server: nginx/1.27.4
Date: Tue, 10 Feb 2026 17:55:12 GMT
Content-Type: text/html
Content-Length: 145
Location: http://localhost/nomad-oasis/docs/404.html
Connection: keep-alive
```

This patch:
```
➜  nomad-distro-template git:(test-index-redirect) curl -I http://localhost/nomad-oasis/docs/
HTTP/1.1 200 OK
Server: nginx/1.27.4
Date: Tue, 10 Feb 2026 18:10:22 GMT
Content-Type: text/html; charset=utf-8
Content-Length: 58749
Connection: keep-alive
Vary: Accept-Encoding
accept-ranges: bytes
last-modified: Tue, 10 Feb 2026 13:11:01 GMT
etag: "b1007847e0ac6127c9642e256b3cbb4a"
cache-control: max-age=60, must-revalidate
```