### PR TITLE
split certificate and private key paths in HTTPS setup guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,8 @@ Below are instructions for how to deploy this NOMAD Oasis distribution
 
    + # HTTPS
    + - ./configs/nginx_https.conf:/etc/nginx/conf.d/default.conf:ro
-   + - ./ssl:/etc/nginx/ssl:ro  # Your certificate files
+   + - ./ssl/selfsigned.crt:/etc/nginx/ssl/selfsigned.crt:ro  # Path to your TLS certificate
+   + - ./ssl/selfsigned.key:/etc/nginx/ssl/selfsigned.key:ro  # Path to your TLS private key
    ```
 
 7. And run it with docker compose in detached (--detach or -d) mode

--- a/README.md
+++ b/README.md
@@ -142,8 +142,8 @@ Below are instructions for how to deploy this NOMAD Oasis distribution
 
    + # HTTPS
    + - ./configs/nginx_https.conf:/etc/nginx/conf.d/default.conf:ro
-   + - ./ssl/selfsigned.crt:/etc/nginx/ssl/selfsigned.crt:ro  # Path to your TLS certificate
-   + - ./ssl/selfsigned.key:/etc/nginx/ssl/selfsigned.key:ro  # Path to your TLS private key
+   + - ./ssl/selfsigned.crt:/etc/nginx/ssl/mounted-nomad-oasis.crt:ro  # Path to your TLS certificate
+   + - ./ssl/selfsigned.key:/etc/nginx/ssl/mounted-nomad-oasis.key:ro  # Path to your TLS private key
    ```
 
 7. And run it with docker compose in detached (--detach or -d) mode

--- a/README.md
+++ b/README.md
@@ -127,11 +127,11 @@ Below are instructions for how to deploy this NOMAD Oasis distribution
       For testing, you can create a [self-signed certificate](https://en.wikipedia.org/wiki/Self-signed_certificate). Note that self-signed certificates are not recommended for production since they are not trusted by browsers. You can generate one with:
 
       ```sh
-      mkdir ssl
+      mkdir tls
       openssl req -x509 -nodes -days 365 \
         -newkey rsa:2048 \
-        -keyout ./ssl/selfsigned.key \
-        -out ./ssl/selfsigned.crt \
+        -keyout ./tls/selfsigned.key \
+        -out ./tls/selfsigned.crt \
         -subj "/CN=localhost"
       ```
 
@@ -142,8 +142,8 @@ Below are instructions for how to deploy this NOMAD Oasis distribution
 
    + # HTTPS
    + - ./configs/nginx_https.conf:/etc/nginx/conf.d/default.conf:ro
-   + - ./ssl/selfsigned.crt:/etc/nginx/ssl/mounted-nomad-oasis.crt:ro  # Path to your TLS certificate
-   + - ./ssl/selfsigned.key:/etc/nginx/ssl/mounted-nomad-oasis.key:ro  # Path to your TLS private key
+   + - ./tls/selfsigned.crt:/etc/nginx/tls/mounted-nomad-oasis.crt:ro  # Path to your TLS certificate
+   + - ./tls/selfsigned.key:/etc/nginx/tls/mounted-nomad-oasis.key:ro  # Path to your TLS private key
    ```
 
 7. And run it with docker compose in detached (--detach or -d) mode

--- a/configs/nginx_https.conf
+++ b/configs/nginx_https.conf
@@ -20,8 +20,8 @@ server {
     server_name localhost;
 
     # SSL configuration
-    ssl_certificate     /etc/nginx/ssl/selfsigned.crt;
-    ssl_certificate_key /etc/nginx/ssl/selfsigned.key;
+    ssl_certificate     /etc/nginx/ssl/mounted-nomad-oasis.crt;
+    ssl_certificate_key /etc/nginx/ssl/mounted-nomad-oasis.key;
 
     proxy_set_header Host $host;
 

--- a/configs/nginx_https.conf
+++ b/configs/nginx_https.conf
@@ -19,9 +19,9 @@ server {
     listen 443 ssl;
     server_name localhost;
 
-    # SSL configuration
-    ssl_certificate     /etc/nginx/ssl/mounted-nomad-oasis.crt;
-    ssl_certificate_key /etc/nginx/ssl/mounted-nomad-oasis.key;
+    # TLS certificate configuration
+    ssl_certificate     /etc/nginx/tls/mounted-nomad-oasis.crt;
+    ssl_certificate_key /etc/nginx/tls/mounted-nomad-oasis.key;
 
     proxy_set_header Host $host;
 


### PR DESCRIPTION
close https://github.com/FAIRmat-NFDI/nomad-distro-template/issues/192

I hope this change combines the best of both worlds:
- if user run the example command to generate self-assigned certificate, they don't need to change any path in config (just like now)
- if they get certificate elsewhere, splitting the two paths would make it easier for them to modify