### PR TITLE
remove `/docs/ -> /docs/index.html` redirect for `docs` from the proxy level 

### DIFF
--- a/configs/nginx_base_conf
+++ b/configs/nginx_base_conf
@@ -37,9 +37,8 @@ location @redirect_to_index {
 }
 
 location /nomad-oasis/docs/ {
-    # TODO: temp fix: redirect /docs/ to /docs/index.html
-    rewrite ^/nomad-oasis/docs/$ /nomad-oasis/docs/index.html break;
-
+    # This is added to force a redirect (302) when 404 otherwise
+    # the assets are not loaded correctly (a broken page rendered)
     proxy_intercept_errors on;
     error_page 404 = @docs404redirect;
     proxy_pass http://app:8000;


### PR DESCRIPTION
https://gitlab.mpcdf.mpg.de/nomad-lab/nomad-FAIR/-/merge_requests/2871

- Accessing `/docs/` redirects to index correctly: 
<img width="970" height="546" alt="image" src="https://github.com/user-attachments/assets/57874632-5c61-4585-b843-a0c048a90e8d" />

