### PR TITLE
Change dependabot base/target branch to `develop`, add dependency cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,8 @@ updates:
     target-branch: "develop"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 3
     allow:
       - dependency-type: all
 
@@ -21,6 +23,8 @@ updates:
     # Check for updates once a week
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 3
 
   # Update action versions
   - package-ecosystem: "github-actions"
@@ -28,3 +32,5 @@ updates:
     target-branch: "develop"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 3

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,7 @@ version: 2
 updates:
   - package-ecosystem: "uv"
     directory: "/"
+    target-branch: "develop"
     schedule:
       interval: "weekly"
     allow:
@@ -16,6 +17,7 @@ updates:
   - package-ecosystem: "docker"
     # Look for a `Dockerfile` in the `root` directory
     directory: "/"
+    target-branch: "develop"
     # Check for updates once a week
     schedule:
       interval: "weekly"
@@ -23,6 +25,6 @@ updates:
   # Update action versions
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "develop"
     schedule:
-      interval: "weekly" 
-
+      interval: "weekly"


### PR DESCRIPTION


Looks like [this config could change the base and target branch at the same time](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#target-branch-):

> Define a specific branch to check for version updates and to target pull requests for version updates against. For examples, see [Customizing Dependabot pull requests to fit your processes](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/customizing-dependabot-prs).
> 
> Dependabot default behavior:
> 
> Dependabot uses the default branch for the repository, see [About the default branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-branches#about-the-default-branch).
> When target-branch is defined:
> 
> Only manifest files on the target branch are checked for version updates.
> All pull requests for version updates are opened targeting the specified branch.
> Options defined for this package-ecosystem no longer apply to security updates because security updates always use the default branch for the repository.

- [ ] https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#cooldown-