### PR TITLE
Fix worker restart policy: use "unless-stopped"

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -162,11 +162,6 @@ services:
         limits:
           cpus: "4.0" # Maximum 4 CPU cores
           memory: 8G # Maximum 8GB RAM
-      restart_policy:
-        condition: on-failure
-        delay: 5s
-        max_attempts: 15
-        window: 1800s
 
   ## nomad gpu worker (actions)
   # gpu_worker:


### PR DESCRIPTION
https://discord.com/channels/1201445470485106719/1511264040507150439

currently out worker has both:
- https://github.com/FAIRmat-NFDI/nomad-distro-template/blob/dc1b7e549a136babc6e1617c996a82de728c5588/docker-compose.yaml#L129
- https://github.com/FAIRmat-NFDI/nomad-distro-template/blob/dc1b7e549a136babc6e1617c996a82de728c5588/docker-compose.yaml#L165-L169


and [`restart_policy` takes higher precedence](https://docs.docker.com/reference/compose-file/deploy/#restart_policy):
> restart_policy configures if and how to restart containers when they exit. If restart_policy is not set, Compose considers the restart field set by the service configuration.


