### PR TITLE
Modified NORTH setup

### DIFF
--- a/.volumes/north_hub/.gitignore
+++ b/.volumes/north_hub/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/.volumes/north_hub/.gitignore
+++ b/.volumes/north_hub/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/README.md
+++ b/README.md
@@ -246,15 +246,14 @@ Any pushes to the main branch of this repository, such as when [adding a plugin]
         newgrp docker
         ```
 
+    > [!NOTE]
+    >
+    > On MacOS, you may need to explicitly say that the NORTH service should run under root. You can do this but adding this to the `north` service:
+    > ```
+    > user: root
+    > ```
+
 2. Customize the previously generated `.env.north` file with the correct values for your Keycloak instance.
-
-3. To run `north` container as non-root user, it has to be run under the docker group. You might need to replace the `user` setting in the `docker-compose.yaml`'s `north` section with your systems docker group id:
-
-    ```yaml
-    user: "1000:991" # replace 991 with your host's docker group id
-    ```
-
-    You can run run `getent group | grep docker` (or `id` if you are a docker user) to find your system's docker gid. The user id `1000` is used as the nomad user inside all containers. No extra volume permission step is needed: NORTH stores its JupyterHub data in `./.volumes/north_hub`, which the `sudo chown -R 1000 .volumes` step from the Quick-start already gives to the user.
 
 Please see the [Jupyter image](#the-jupyter-image) section below for more information on the jupyter NORTH image being generated in this repository.
 

--- a/README.md
+++ b/README.md
@@ -248,14 +248,14 @@ Any pushes to the main branch of this repository, such as when [adding a plugin]
 
 2. Customize the previously generated `.env.north` file with the correct values for your Keycloak instance.
 
-3. Uncomment the `user` line in the `docker-compose.yaml`'s `north` section and set the group to your host's `docker` group id so the container can still reach the mounted docker socket:
+3. To make the NORTH tools run as non-root, uncomment the `user` line in the `docker-compose.yaml`'s `north` section and set the group to your host's `docker` group id. This way the container can still reach the mounted docker socket.
 
     ```yaml
     user: "1000:991" # replace 991 with your host's docker group id
     ```
 
     - Run `getent group docker` (or `id` if you are a docker user) to find your system's docker gid.
-    - No extra volume permission step is needed: NORTH stores its JupyterHub data in `./.volumes/north_hub`, which the `sudo chown -R 1000 .volumes` step from the Quick-start already gives to the nomad user.
+    - No extra volume permission step is needed: NORTH stores its JupyterHub data in `./.volumes/north_hub`, which the `sudo chown -R 1000 .volumes` step from the Quick-start already gives to the user.
 
 Please see the [Jupyter image](#the-jupyter-image) section below for more information on the jupyter NORTH image being generated in this repository.
 

--- a/README.md
+++ b/README.md
@@ -246,12 +246,16 @@ Any pushes to the main branch of this repository, such as when [adding a plugin]
         newgrp docker
         ```
 
-2. To run `north` container as non-root user, it has to be run under the docker group. You might need to replace the `user` setting in the `docker-compose.yaml`'s `north` section with your systems docker group id (eg.: `user: '1000:911'`).
-    - The user id `1000` is used as the nomad user inside all containers.
-    - Run `id` if you are a docker user, or `getent group | grep docker` to find your systems docker gid.
+2. Customize the previously generated `.env.north` file with the correct values for your Keycloak instance.
 
-3. Customize the previously generated `.env.north` file with the correct values for your Keycloak instance.
+3. Uncomment the `user` line in the `docker-compose.yaml`'s `north` section and set the group to your host's `docker` group id so the container can still reach the mounted docker socket:
 
+    ```yaml
+    user: "1000:991" # replace 991 with your host's docker group id
+    ```
+
+    - Run `getent group docker` (or `id` if you are a docker user) to find your system's docker gid.
+    - No extra volume permission step is needed: NORTH stores its JupyterHub data in `./.volumes/north_hub`, which the `sudo chown -R 1000 .volumes` step from the Quick-start already gives to the nomad user.
 
 Please see the [Jupyter image](#the-jupyter-image) section below for more information on the jupyter NORTH image being generated in this repository.
 
@@ -585,10 +589,9 @@ Sometimes there are significant changes in these distribution templates, and you
 
 ## FAQ/Trouble shooting
 
-_I get an_ `Error response from daemon: Head "https://ghcr.io/v2/{{ image_name }}/manifests/main": unauthorized`
-_when trying to pull my docker image._
+- _I get an_ `Error response from daemon: Head "https://ghcr.io/v2/{{ image_name }}/manifests/main": unauthorized` _when trying to pull my docker image._
 
-Most likely you have not made the package public or provided a personal access token (PAT).
+   Most likely you have not made the package public or provided a personal access token (PAT).
 You can read how to make your package public in the GitHub docs [here](https://docs.github.com/en/packages/learn-github-packages/configuring-a-packages-access-control-and-visibility)
 or how to configure a PAT (if you want to keep the distribution private) in the GitHub
 docs [here](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-with-a-personal-access-token-classic).

--- a/README.md
+++ b/README.md
@@ -248,14 +248,13 @@ Any pushes to the main branch of this repository, such as when [adding a plugin]
 
 2. Customize the previously generated `.env.north` file with the correct values for your Keycloak instance.
 
-3. To make the NORTH tools run as non-root, uncomment the `user` line in the `docker-compose.yaml`'s `north` section and set the group to your host's `docker` group id. This way the container can still reach the mounted docker socket.
+3. To run `north` container as non-root user, it has to be run under the docker group. You might need to replace the `user` setting in the `docker-compose.yaml`'s `north` section with your systems docker group id:
 
     ```yaml
     user: "1000:991" # replace 991 with your host's docker group id
     ```
 
-    - Run `getent group docker` (or `id` if you are a docker user) to find your system's docker gid.
-    - No extra volume permission step is needed: NORTH stores its JupyterHub data in `./.volumes/north_hub`, which the `sudo chown -R 1000 .volumes` step from the Quick-start already gives to the user.
+    You can run run `getent group | grep docker` (or `id` if you are a docker user) to find your system's docker gid. The user id `1000` is used as the nomad user inside all containers. No extra volume permission step is needed: NORTH stores its JupyterHub data in `./.volumes/north_hub`, which the `sudo chown -R 1000 .volumes` step from the Quick-start already gives to the user.
 
 Please see the [Jupyter image](#the-jupyter-image) section below for more information on the jupyter NORTH image being generated in this repository.
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -127,14 +127,7 @@ services:
   # nomad worker (processing)
   worker:
     restart: unless-stopped
-    build:
-      context: .
-      dockerfile: Dockerfile
-      target: final
-      args:
-        PYTHON_VERSION: "3.12"
-        UV_VERSION: "0.9"
-    image: nomad-oasis:local
+    image: ghcr.io/fairmat-nfdi/nomad-distro-template:main
     platform: linux/amd64
     environment:
       NOMAD_SERVICE: nomad_oasis_worker
@@ -264,14 +257,7 @@ services:
   # nomad app (api + proxy)
   app:
     restart: unless-stopped
-    build:
-      context: .
-      dockerfile: Dockerfile
-      target: final
-      args:
-        PYTHON_VERSION: "3.12"
-        UV_VERSION: "0.9"
-    image: nomad-oasis:local
+    image: ghcr.io/fairmat-nfdi/nomad-distro-template:main
     platform: linux/amd64
     container_name: nomad_oasis_app
     environment:
@@ -354,14 +340,7 @@ services:
   # to enable the logtransfer service run "docker compose --profile with_logtransfer up"
   logtransfer:
     restart: unless-stopped
-    build:
-      context: .
-      dockerfile: Dockerfile
-      target: final
-      args:
-        PYTHON_VERSION: "3.12"
-        UV_VERSION: "0.9"
-    image: nomad-oasis:local
+    image: ghcr.io/fairmat-nfdi/nomad-distro-template:main
     platform: linux/amd64
     container_name: nomad_oasis_logtransfer
     environment:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -127,7 +127,14 @@ services:
   # nomad worker (processing)
   worker:
     restart: unless-stopped
-    image: ghcr.io/fairmat-nfdi/nomad-distro-template:main
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: final
+      args:
+        PYTHON_VERSION: "3.12"
+        UV_VERSION: "0.9"
+    image: nomad-oasis:local
     platform: linux/amd64
     environment:
       NOMAD_SERVICE: nomad_oasis_worker
@@ -257,7 +264,14 @@ services:
   # nomad app (api + proxy)
   app:
     restart: unless-stopped
-    image: ghcr.io/fairmat-nfdi/nomad-distro-template:main
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: final
+      args:
+        PYTHON_VERSION: "3.12"
+        UV_VERSION: "0.9"
+    image: nomad-oasis:local
     platform: linux/amd64
     container_name: nomad_oasis_app
     environment:
@@ -310,9 +324,17 @@ services:
       # Bind Docker socket on the host so we can connect to the daemon from
       # within the container
       - "/var/run/docker.sock:/var/run/docker.sock:rw"
-      # Bind Docker volume on host for JupyterHub database and cookie secrets
-      - "nomad_north:/data"
+      # JupyterHub database and cookie secrets. Bind-mounted under .volumes so the
+      # `sudo chown -R 1000 .volumes` setup step also owns it (needed when running
+      # NORTH as the non-root user; see the NORTH section in the README).
+      - "./.volumes/north_hub:/data"
+    # By default NORTH runs as root, which works out of the box. To run it as the
+    # non-root nomad user (1000) instead, uncomment the line below and set the group
+    # to your host's `docker` group ID (see the NORTH section in the README).
     # user: "1000:991"
+    # JupyterHub writes its proxy pid file to the working directory (not writable by a
+    # non-root user) by default; redirect it into /data so the non-root option works too.
+    command: jupyterhub --ConfigurableHTTPProxy.pid_file=/data/jupyterhub-proxy.pid
     healthcheck:
       test:
         - "CMD"
@@ -332,7 +354,14 @@ services:
   # to enable the logtransfer service run "docker compose --profile with_logtransfer up"
   logtransfer:
     restart: unless-stopped
-    image: ghcr.io/fairmat-nfdi/nomad-distro-template:main
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: final
+      args:
+        PYTHON_VERSION: "3.12"
+        UV_VERSION: "0.9"
+    image: nomad-oasis:local
     platform: linux/amd64
     container_name: nomad_oasis_logtransfer
     environment:
@@ -397,8 +426,6 @@ volumes:
     name: "nomad_oasis_keycloak"
   postgresql:
     name: "nomad_oasis_postgresql"
-  nomad_north:
-    name: "nomad_oasis_north"
 
 
 networks:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -310,17 +310,8 @@ services:
       # Bind Docker socket on the host so we can connect to the daemon from
       # within the container
       - "/var/run/docker.sock:/var/run/docker.sock:rw"
-      # JupyterHub database and cookie secrets. Bind-mounted under .volumes so the
-      # `sudo chown -R 1000 .volumes` setup step also owns it (needed when running
-      # NORTH as the non-root user; see the NORTH section in the README).
-      - "./.volumes/north_hub:/data"
-    # By default NORTH runs as root, which works out of the box. To run it as the
-    # non-root nomad user (1000) instead, uncomment the line below and set the group
-    # to your host's `docker` group ID (see the NORTH section in the README).
-    # user: "1000:991"
-    # JupyterHub writes its proxy pid file to the working directory (not writable by a
-    # non-root user) by default; redirect it into /data so the non-root option works too.
-    command: jupyterhub --ConfigurableHTTPProxy.pid_file=/data/jupyterhub-proxy.pid
+      # Bind Docker volume on host for JupyterHub database and cookie secrets
+      - "nomad_north:/data"
     healthcheck:
       test:
         - "CMD"
@@ -405,6 +396,8 @@ volumes:
     name: "nomad_oasis_keycloak"
   postgresql:
     name: "nomad_oasis_postgresql"
+  nomad_north:
+    name: "nomad_oasis_north"
 
 
 networks:


### PR DESCRIPTION
@fekad Could you take a look at these changes and see if you approve them.

As a background: I had significant trouble in running the refactored NORTH on my linux machine. The issues were:

- The `nomad_north` volume by default is only readable by the `root` user. So I got issues like `Permission denied: '/data/jupyterhub_cookie_secret'`, because the data was not readable when I switch to the the user `1000`.
- At startup, Jupyter is writing a file `jupyterhub-proxy.pid` into a directory that is not readable by user `1000`, leading also to a similar permission problem.

To fix these, I now changed NORT to use a bind-mounted location inside `.volumes` instead of a dedicated volume. I think this makes everythign quite a bit easier. I think otherwise we will get a lot of permissions questions. Also, I changed the default command to change the location of the `jupyterhub-proxy.pid` file to use that bind-mounted volume, which now has the required permissions.

Take a look at this, and tell me what you think. If this looks OK to you (after these, everything worked nicely!) then we merge.