### PR TITLE
run on newer Linux kernels

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -24,7 +24,7 @@ services:
   # the user data db
   mongo:
     restart: unless-stopped
-    image: docker.io/mongo:8.0
+    image: docker.io/mongo:8.0.4
     container_name: nomad_oasis_mongo
     environment:
       - MONGO_DATA_DIR=/data/db


### PR DESCRIPTION
error message is:
MongoDB cannot start: Linux kernel versions 6.19 and newer has a known incompatibility with this version of MongoDB. See https://jira.mongodb.org/browse/SERVER-121912 for more information.

according to OpenCode, 8.0.4 is working in all cases. I can confirm that for 7.1.5-arch1-2